### PR TITLE
Hotfix to add a missing .gitignore

### DIFF
--- a/content/wk05/.gitignore
+++ b/content/wk05/.gitignore
@@ -1,0 +1,1 @@
+solution

--- a/content/wk05/assignment.md
+++ b/content/wk05/assignment.md
@@ -108,7 +108,13 @@ Consider the following questions.
  - Are there an equal number of reads from each sample?
  - Are the read lengths the same between each sample?
  
- 
+
+### Clean up
+
+When you are done, check the files in the `content/wk05` folder.
+Ensure that you haven't commited any fastq files or gz files into the repo.
+If you have, use `git rm {path}` to remove the file.
+
 ## Project Task
 
 ### Exploration


### PR DESCRIPTION
I missed adding the `.gitignore` file when creating from our skeleton. This ensures that you don't accidentally add anything in the solutions folder.

If you have accidentally added them. Don't worry. Just use `git rm {path}` to remove them.

If you've saved your notes file to something like `content/wk05/solutions/notes.md`. Then make sure rename it with your user name or move it to the `excercises/{user}/wk05_notes.md`
